### PR TITLE
refactor: set default values via stimulus values api instead of in ternary

### DIFF
--- a/app/javascript/controllers/fields/date_controller.js
+++ b/app/javascript/controllers/fields/date_controller.js
@@ -9,8 +9,8 @@ export default class extends Controller {
   static values = {
     includeTime: Boolean,
     defaultTimeZones: Array,
-    cancelButtonLabel: String,
-    applyButtonLabel: String
+    cancelButtonLabel: { type: String, default: "Cancel" },
+    applyButtonLabel: { type: String, default: "Apply" }
   }
 
   connect() {
@@ -86,8 +86,8 @@ export default class extends Controller {
       timePickerIncrement: 5,
       autoUpdateInput: false,
       locale: {
-        cancelLabel: (this.hasCancelButtonLabelValue)? this.cancelButtonLabelValue: "cancel",
-        applyLabel: (this.hasApplyButtonLabelValue)? this.applyButtonLabelValue: "apply",
+        cancelLabel: this.cancelButtonLabelValue,
+        applyLabel: this.applyButtonLabelValue,
         format: this.includeTimeValue ? 'MM/DD/YYYY h:mm A' : 'MM/DD/YYYY'
       }
     })


### PR DESCRIPTION
Stimulus values API has the ability to set default values. I came across this file today and thought this minor improvement would be beneficial. It's a little easier to understand what these values will be set to by seeing them in the `values` object, rather than having to parse the file looking for where they get set down in the `initPluginInstance()` function.