### PR TITLE
Prepare repository for running Minitest tests

### DIFF
--- a/lib/bullet_train/fields/engine.rb
+++ b/lib/bullet_train/fields/engine.rb
@@ -2,7 +2,10 @@ module BulletTrain
   module Fields
     class Engine < ::Rails::Engine
       initializer "bullet_train.fields" do |app|
-        BulletTrain.linked_gems << "bullet_train-fields"
+        # Older versions of Bullet Train have a `BulletTrain` module, but it doesn't have `linked_gems`.
+        if BulletTrain.respond_to?(:linked_gems)
+          BulletTrain.linked_gems << "bullet_train-fields"
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #18.

## Details
As stated in #18, there is a workaround in `bullet_train-super_scaffolding` which I decided to implement here as well. If we're okay with this, then we can probably get CircleCI up and running on this repository as well.

I'm not entirely sure how we should handle the `BulletTrain` module here, but since we've been fine with the same logic in `bullet_train-super_scaffolding`, I figured it would be fine here too.