### PR TITLE
Fix color picker

### DIFF
--- a/app/javascript/controllers/fields/color_picker_controller.js
+++ b/app/javascript/controllers/fields/color_picker_controller.js
@@ -4,8 +4,9 @@ import '@simonwep/pickr/dist/themes/monolith.min.css'
 import Pickr from '@simonwep/pickr';
 
 export default class extends Controller {
-  static targets = [ "colorPickerValue", "colorField", "colorInput", "userSelectedColor", "colorOptions", "pickerContainer", "togglePickerButton" ];
+  static targets = [ "colorPickerValue", "colorField", "colorInput", "userSelectedColor", "colorOptions", "pickerContainer", "togglePickerButton", "colorButton" ];
   static values = { initialColor: String }
+  static classes = [ "colorSelected" ]
 
   connect() {
     this.initPluginInstance()
@@ -25,11 +26,9 @@ export default class extends Controller {
     $(this.colorInputTarget).val(color);
     $(this.colorPickerValueTarget).val(color);
     $(this.userSelectedColorTarget).data('color', color);
-    $('.button-color').removeClass('ring-2 ring-offset-2');
+    this.highlightColorButtonsMatchingSelectedColor()
 
     this.pickr.setColor(color);
-
-    targetEl.classList.add('ring-2', 'ring-offset-2');
   }
 
   pickRandomColor(event) {
@@ -50,7 +49,7 @@ export default class extends Controller {
     $(this.colorInputTarget).val(color);
     $(this.colorPickerValueTarget).val(color);
 
-    $('.button-color').removeClass('ring-2 ring-offset-2');
+    this.highlightColorButtonsMatchingSelectedColor()
 
     $(this.userSelectedColorTarget)
       .addClass('ring-2')
@@ -66,7 +65,18 @@ export default class extends Controller {
     $(this.colorPickerValueTarget).val('');
     $(this.colorInputTarget).val('');
     $(this.userSelectedColorTarget).hide();
-    $('.button-color').removeClass('ring-2 ring-offset-2');
+    this.highlightColorButtonsMatchingSelectedColor()
+  }
+  
+  highlightColorButtonsMatchingSelectedColor() {
+    this.colorButtonTargets.forEach((button) => {
+      const buttonColor = button.dataset?.color
+      if (this.selectedColor !== undefined && buttonColor === this.selectedColor) {
+        button.classList.add(...this.colorSelectedClasses)
+      } else {
+        button.classList.remove(...this.colorSelectedClasses)
+      }
+    })
   }
 
   togglePickr(event) {
@@ -112,5 +122,9 @@ export default class extends Controller {
 
   teardownPluginInstance() {
     this.pickr.destroy()
+  }
+  
+  get selectedColor() {
+    return $(this.colorInputTarget).val()
   }
 }

--- a/app/javascript/controllers/fields/color_picker_controller.js
+++ b/app/javascript/controllers/fields/color_picker_controller.js
@@ -3,6 +3,8 @@ import '@simonwep/pickr/dist/themes/monolith.min.css'
 
 import Pickr from '@simonwep/pickr';
 
+const pickerHexInputSelector = 'input.pcr-result'
+
 export default class extends Controller {
   static targets = [ "colorPickerValue", "colorField", "colorInput", "userSelectedColor", "colorOptions", "pickerContainer", "togglePickerButton", "colorButton" ];
   static values = { initialColor: String }
@@ -113,7 +115,7 @@ export default class extends Controller {
   }
   
   handleKeydown(event) {
-    if (!event.target.matches('input.pcr-result')) { return }
+    if (!event.target.matches(pickerHexInputSelector)) { return }
     if (event.key !== 'Enter') { return }
     
     event.preventDefault()

--- a/app/javascript/controllers/fields/color_picker_controller.js
+++ b/app/javascript/controllers/fields/color_picker_controller.js
@@ -4,7 +4,7 @@ import '@simonwep/pickr/dist/themes/monolith.min.css'
 import Pickr from '@simonwep/pickr';
 
 export default class extends Controller {
-  static targets = [ "colorPickerValue", "colorField", "colorInput", "userSelectedColor", "colorOptions" ];
+  static targets = [ "colorPickerValue", "colorField", "colorInput", "userSelectedColor", "colorOptions", "pickerContainer", "togglePickerButton" ];
   static values = { initialColor: String }
 
   connect() {
@@ -75,7 +75,8 @@ export default class extends Controller {
 
   initPluginInstance() {
     this.pickr = Pickr.create({
-      el: '.btn-pickr',
+      el: this.togglePickerButtonTarget,
+      container: this.pickerContainerTarget,
       theme: 'monolith',
       useAsButton: true,
       default: this.initialColorValue || '#1E90FF',

--- a/app/javascript/controllers/fields/color_picker_controller.js
+++ b/app/javascript/controllers/fields/color_picker_controller.js
@@ -110,14 +110,15 @@ export default class extends Controller {
       }
       this.pickr.hide();
     });
-
-    const that = this
-
-    $('input[type="text"].pcr-result').on('keydown', function (e) {
-      if (e.key === 'Enter') {
-        that.pickr.applyColor(false)
-      }
-    })
+  }
+  
+  handleKeydown(event) {
+    if (!event.target.matches('input.pcr-result')) { return }
+    if (event.key !== 'Enter') { return }
+    
+    event.preventDefault()
+    event.stopPropagation()
+    this.pickr.applyColor(false)
   }
 
   teardownPluginInstance() {


### PR DESCRIPTION
This PR requires the changes made in:

- https://github.com/bullet-train-co/bullet_train-themes-tailwind_css/pull/10

Changes:

- [X] multiple color pickers: fix showing the picker from pencil button on other instances on page, fixes #23 
- [X] multiple color pickers: fix highlighting the selected color button of just the current instance
- [X] properly remove event listeners on disconnect, use proper data-action for handleKeydown
- [X] prevent pressing Enter key from submitting whole form, stop Propagation