### PR TITLE
fix: specify super_select dropdownParent

### DIFF
--- a/app/javascript/controllers/fields/super_select_controller.js
+++ b/app/javascript/controllers/fields/super_select_controller.js
@@ -40,7 +40,9 @@ export default class extends Controller {
   }
 
   initPluginInstance() {
-    let options = {};
+    let options = {
+      dropdownParent: $(this.element)
+    };
 
     if (!this.enableSearchValue) {
       options.minimumResultsForSearch = -1;


### PR DESCRIPTION
From the [select2 docs](https://select2.org/dropdown#dropdown-placement):

> By default, Select2 will attach the dropdown to the end of the body and will absolutely position it to appear above or below the selection container.

This can be problematic when a super select field is rendered in an element with an ancestor set to be non-interact-able via `overflow: hidden` or [`inert`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert), causing the inability to use the dropdown search.

To resolve the issue, this change specifies the `dropdownParent` as `this.element`, ensuring that the dropdown element remains with the super select parent element field. 