### PR TITLE
super_select: allow catching keydown and opening on click

### DIFF
--- a/app/javascript/controllers/fields/super_select_controller.js
+++ b/app/javascript/controllers/fields/super_select_controller.js
@@ -40,7 +40,9 @@ export default class extends Controller {
   }
 
   initPluginInstance() {
-    let options = {};
+    let options = {
+      dropdownParent: $(this.element)
+    };
 
     if (!this.enableSearchValue) {
       options.minimumResultsForSearch = -1;

--- a/app/javascript/controllers/fields/super_select_controller.js
+++ b/app/javascript/controllers/fields/super_select_controller.js
@@ -2,6 +2,9 @@ import { Controller } from "@hotwired/stimulus"
 require("select2/dist/css/select2.min.css");
 import select2 from "select2";
 
+const select2SelectedPreviewSelector = ".select2-selection--single"
+const select2SearchInputFieldSelector = ".select2-search__field"
+
 export default class extends Controller {
   static targets = [ "select" ]
   static values = {
@@ -85,6 +88,32 @@ export default class extends Controller {
     
     // revert to original markup, remove any event listeners
     $(this.pluginMainEl).select2('destroy');
+  }
+  
+  open() {
+    $(this.pluginMainEl).select2('open')
+  }
+  
+  focusOnTextField(event) {
+    this.element.querySelector(select2SearchInputFieldSelector)?.focus()
+  }
+  
+  injectKeystrokeIntoTextField(event) {
+    if (!event?.srcElement.matches(select2SelectedPreviewSelector)) { return }
+    
+    if (["Shift", "Alt", "Control", "Meta", "Tab", "Backspace", "Escape"].includes(event.key)) { return }
+    
+    this.open()
+    
+    const searchInputField = this.element.querySelector(select2SearchInputFieldSelector)
+    
+    if (!searchInputField) { return }
+
+    if (event.type !== "keydown") {
+      // since keydown precedes keyup, and since keyup is what sends the key to an input field, this next line isn't necessary if keydown is the event captured. We'll just focus on the input field, and the keyup will caught by the input field naturally.
+      searchInputField.value = searchInputField.value + event.key
+    }
+    searchInputField.focus()
   }
 
   initReissuePluginEventsAsNativeEvents() {


### PR DESCRIPTION
For `super_select` fields that don't allow multiple selections, this introduces these improvements:

1. When clicking on the field, the focus goes onto the search text input field
2. When closed, but the field has focus, if you start typing, the field opens and lets you type directly into the search text input field.

Closes https://github.com/bullet-train-co/bullet_train-fields/issues/35

Requires https://github.com/bullet-train-co/bullet_train-fields/pull/33 (a commit from that PR's branch is included in this branch)

Co-dependent PRs:
* https://github.com/bullet-train-co/bullet_train-themes/pull/21
* https://github.com/bullet-train-co/bullet_train/pull/435