### PR TITLE
Super-select: update on dependent field

### DIFF
--- a/app/javascript/controllers/dependable_controller.js
+++ b/app/javascript/controllers/dependable_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    dependentsSelector: String
+  }
+
+  updateDependents(event) {
+    if (!this.hasDependents) { return false }
+    
+    this.dependents.forEach((dependent) => {
+      dependent.dispatchEvent(new CustomEvent(`${this.identifier}:updated`, { detail: { event: event }, bubbles: true, cancelable: false }))
+    })
+  }
+  
+  get hasDependents() {
+    return (this.dependents.length > 0)
+  }
+  
+  get dependents() {
+    if (!this.dependentsSelectorValue) { return [] }
+    return document.querySelectorAll(this.dependentsSelectorValue)
+  }
+}

--- a/app/javascript/controllers/fields/super_select_controller.js
+++ b/app/javascript/controllers/fields/super_select_controller.js
@@ -8,6 +8,9 @@ export default class extends Controller {
     acceptsNew: Boolean,
     enableSearch: Boolean,
     searchUrl: String,
+    // searchUrlPattern: String,
+    // queryStringMappings: Object,
+    // searchUrlParams: Object
   }
   
   // will be reissued as native dom events name prepended with '$' e.g. '$change', '$select2:closing', etc
@@ -83,6 +86,16 @@ export default class extends Controller {
     
     // revert to original markup, remove any event listeners
     $(this.pluginMainEl).select2('destroy');
+  }
+  
+  updateSearchUrlValue(event) {
+    const dependentOnField = event?.detail?.event?.target
+    if (!dependentOnField) { return }
+    
+    const fieldName = dependentOnField.name
+    const fieldValue = dependentOnField.value
+    
+    // this.updateUrlParamsFrom(fieldName, fieldValue)
   }
 
   initReissuePluginEventsAsNativeEvents() {

--- a/app/javascript/controllers/fields/super_select_controller.js
+++ b/app/javascript/controllers/fields/super_select_controller.js
@@ -99,7 +99,7 @@ export default class extends Controller {
   
   dispatchNativeEvent(event) {
     const nativeEventName = '$' + event.type // e.g. '$change.select2'
-    this.element.dispatchEvent(new CustomEvent(nativeEventName, { detail: { event: event }, bubbles: true, cancelable: false }))
+    this.pluginMainEl.dispatchEvent(new CustomEvent(nativeEventName, { detail: { event: event }, bubbles: true, cancelable: false }))
   }
 
   // https://stackoverflow.com/questions/29290389/select2-add-image-icon-to-option-dynamically

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,6 +9,7 @@ import FileFieldController from './fields/file_field_controller'
 import PasswordController from './fields/password_controller'
 import PhoneController from './fields/phone_controller'
 import SuperSelectController from './fields/super_select_controller'
+import DependableController from './dependable_controller'
 
 export const controllerDefinitions = [
   [ButtonToggleController, 'fields/button_toggle_controller.js'],
@@ -20,6 +21,7 @@ export const controllerDefinitions = [
   [PasswordController, 'fields/password_controller.js'],
   [PhoneController, 'fields/phone_controller.js'],
   [SuperSelectController, 'fields/super_select_controller.js'],
+  [DependableController, 'dependable_controller.js'],
 ].map(function(d) {
   const key = d[1]
   const controller = d[0]
@@ -39,4 +41,5 @@ export {
   PasswordController,
   PhoneController,
   SuperSelectController,
+  DependableController,
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "yalc": "^1.0.0-pre.53"
   },
   "dependencies": {
-    "@hotwired/stimulus": "^3.0.1",
+    "@hotwired/stimulus": "^3.2.0",
     "@simonwep/pickr": "^1.8.1",
     "daterangepicker": "^3.1.0",
     "emoji-mart": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "yalc": "^1.0.0-pre.53"
   },
   "dependencies": {
-    "@hotwired/stimulus": "^3.2.0",
+    "@hotwired/stimulus": "^3.0.1",
     "@simonwep/pickr": "^1.8.1",
     "daterangepicker": "^3.1.0",
     "emoji-mart": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1011,7 +1011,7 @@
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus-webpack-helpers/-/stimulus-webpack-helpers-1.0.1.tgz#4cd74487adeca576c9865ac2b9fe5cb20cef16dd"
   integrity sha512-wa/zupVG0eWxRYJjC1IiPBdt3Lruv0RqGN+/DTMmUWUyMAEB27KXmVY6a8YpUVTM7QwVuaLNGW4EqDgrS2upXQ==
 
-"@hotwired/stimulus@^3.2.0":
+"@hotwired/stimulus@^3.0.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.1.tgz#e3de23623b0c52c247aba4cd5d530d257008676b"
   integrity sha512-HGlzDcf9vv/EQrMJ5ZG6VWNs8Z/xMN+1o2OhV1gKiSG6CqZt5MCBB1gRg5ILiN3U0jEAxuDTNPRfBcnZBDmupQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1011,10 +1011,10 @@
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus-webpack-helpers/-/stimulus-webpack-helpers-1.0.1.tgz#4cd74487adeca576c9865ac2b9fe5cb20cef16dd"
   integrity sha512-wa/zupVG0eWxRYJjC1IiPBdt3Lruv0RqGN+/DTMmUWUyMAEB27KXmVY6a8YpUVTM7QwVuaLNGW4EqDgrS2upXQ==
 
-"@hotwired/stimulus@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.0.1.tgz#141f15645acaa3b133b7c247cad58ae252ffae85"
-  integrity sha512-oHsJhgY2cip+K2ED7vKUNd2P+BEswVhrCYcJ802DSsblJFv7mPFVk3cQKvm2vHgHeDVdnj7oOKrBbzp1u8D+KA==
+"@hotwired/stimulus@^3.2.0":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.1.tgz#e3de23623b0c52c247aba4cd5d530d257008676b"
+  integrity sha512-HGlzDcf9vv/EQrMJ5ZG6VWNs8Z/xMN+1o2OhV1gKiSG6CqZt5MCBB1gRg5ILiN3U0jEAxuDTNPRfBcnZBDmupQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
Fixes #42

Co-dependent PRs:
* https://github.com/bullet-train-co/bullet_train-themes/pull/26

This PR gives the ability for a super-select to update its options (by updating its searchUrl) based on some other field on whose value it depends on.

It introduces a `dependable_controller.js`, which allows for direct dispatching of events to a `dependent` field without the need for a wrapper controller to coordinate events.

The new `outlets` feature of Stimulus 3.2 was considered, but it's the wrong pattern because it requires tight coupling of the dispatching and the dependent fields (ie. knowledge from the dispatcher of the inner-workings of the receiver controller). Since the `dependable_controller` could be used to also update dependent `turbo_frames` or other arbitrary fields, the `outlets` pattern no longer fits the bill.

### Example:

Let's hook up a `:region` super-select field to update itself with new options when the `:country` field changes (in this case, it's a super-select also, but doesn't have to be):

```erb
<%= render 'shared/fields/super_select',
  method: :country,
  choices: @team.countries.all.map {|c| [c.name, c.id] },
  wrapper_options: {
    data: {
      'controller': "dependable",
      'action': '$change->dependable#updateDependents',
      'dependable-dependents-selector-value': "##{form.field_id(:region)}_wrapper"
    }
  }
%>
<%= render 'shared/fields/super_select',
  method: :region,
  choices: [],
  html_options: { 
    disabled: true
  },
  wrapper_options: {
    id: "#{form.field_id(:region)}_wrapper",
    data: {
      action: "dependable:updated->fields--super-select#updateSearchValue"
    }
  }
%>
```

Tasks:
- [x] add a way for a field to tell its dependent fields that it's been updated
- [ ] add the ability to super-select to catch the new value and update its searchUrl

### Updating the `searchUrl` from a pattern and mappings

For the `searchUrl` to be able to update itself in a number of ways, I'd like to introduce the ability to define `required` and `optional` params for the `searchUrl`.

Given a url pattern like `/account/countries/${headquarter[country]}/regions.json`, the `headquarter[country]` field would be deemed required (can't be empty or null).

Additionally, a set of query string mappings could be provided for optional query string parameters.

e.g. given this `queryStringMapping`
```json
{
  "headquarter[continental_only]": "continental_only",
}
```

If a dependent field named `headquarter[continental_only]` were to tell the super-select that its value is now set to `true`, then the searchUrl would be changed to `/account/countries/1/regions.json?continental_only=true`.

The url pattern could also require the `continental_only` query string by specifying it in the pattern directly:

`/account/countries/${headquarter[country]}/regions.json?continental_only=${headquarter[continental_only]}`

And to make these url params persist a back operation, they would all be saved in a `urlParams` value. An `urlParamChanged()` callback would catch the changes to the urlParams value, assemble the new searchValue if all required params are gathered, and thereby updating the super-select's options via that json request.

This work into updating the searchUrl from this pattern and mappings could be made into a Stimulus mixin, re-usable into other controllers (e.g. for updating a turbo_frame's `src`).